### PR TITLE
HttpUils: use readfile instead of require_once

### DIFF
--- a/src/inc/commons/http.php
+++ b/src/inc/commons/http.php
@@ -10,7 +10,7 @@ class HttpUtils
 	
 	public static function WriteFile($path, $mime = "text/plain") {
 		header('Content-Type: '.$mime);
-		require_once($path);
+		readfile($path);
 		die();
 	}
 	


### PR DESCRIPTION
Fixes an error when browsing to /$metadata, the required xml file was loaded using require_once which caused a PHP_PARSE error.